### PR TITLE
Fix assert by replacing to optional of

### DIFF
--- a/lib/src/widgets/reorder_flex/reorder_flex.dart
+++ b/lib/src/widgets/reorder_flex/reorder_flex.dart
@@ -202,7 +202,7 @@ class ReorderFlexState extends State<ReorderFlex>
         ScrollController();
 
     if (_scrollController.hasClients) {
-      _attachedScrollPosition = Scrollable.of(context)?.position;
+      _attachedScrollPosition = Scrollable.maybeOf(context)?.position;
     } else {
       _attachedScrollPosition = null;
     }
@@ -595,7 +595,7 @@ class ReorderFlexState extends State<ReorderFlex>
 
   Widget _wrapScrollView({required Widget child}) {
     if (widget.scrollController != null &&
-        PrimaryScrollController.of(context) == null) {
+        PrimaryScrollController.maybeOf(context) == null) {
       return child;
     } else {
       return SingleChildScrollView(
@@ -691,7 +691,7 @@ class ReorderFlexState extends State<ReorderFlex>
     if (_scrolling) return;
     final RenderObject contextObject = context.findRenderObject()!;
     final RenderAbstractViewport viewport =
-        RenderAbstractViewport.of(contextObject)!;
+        RenderAbstractViewport.of(contextObject);
     // If and only if the current scroll offset falls in-between the offsets
     // necessary to reveal the selected context at the top or bottom of the
     // screen, then it is already on-screen.


### PR DESCRIPTION
Currently, the logic is a bit broken because `.of(...)` is not an option, but in code assuming it's. 
I have updated it to make it optional but did not change any logic behind this.

This is related to #1 as well.

For reference how `.of(..)` looks like
![Screenshot 2023-03-17 at 5 42 09 PM](https://user-images.githubusercontent.com/4023904/225855842-7f52dbde-4015-43c0-813b-17818028ac75.png)
