### PR TITLE
feat: mobile improvement

### DIFF
--- a/example/lib/multi_board_list_example.dart
+++ b/example/lib/multi_board_list_example.dart
@@ -77,7 +77,7 @@ class _MultiBoardListExampleState extends State<MultiBoardListExample> {
             icon: const Icon(Icons.add, size: 20),
             title: const Text('New'),
             height: 50,
-            margin: config.groupItemPadding,
+            margin: config.groupBodyPadding,
             onAddButtonClick: () {
               boardController.scrollToBottom(columnData.id);
             },
@@ -101,7 +101,7 @@ class _MultiBoardListExampleState extends State<MultiBoardListExample> {
             addIcon: const Icon(Icons.add, size: 20),
             moreIcon: const Icon(Icons.more_horiz, size: 20),
             height: 50,
-            margin: config.groupItemPadding,
+            margin: config.groupBodyPadding,
           );
         },
         groupConstraints: const BoxConstraints.tightFor(width: 240),

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -325,11 +325,13 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
     }
 
     if (index == 0) {
-      return EdgeInsets.only(right: widget.config.groupPadding.right);
+      // remove the left padding of the first group
+      return widget.config.groupPadding.copyWith(left: 0);
     }
 
     if (index == widget.dataController.groupDatas.length - 1) {
-      return EdgeInsets.only(left: widget.config.groupPadding.left);
+      // remove the right padding of the last group
+      return widget.config.groupPadding.copyWith(right: 0);
     }
 
     return widget.config.groupPadding;

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -20,18 +20,25 @@ class AppFlowyBoardScrollController {
 }
 
 class AppFlowyBoardConfig {
+  // overall board
+  final EdgeInsets boardPadding;
   final double cornerRadius;
-  final EdgeInsets groupPadding;
-  final EdgeInsets groupItemPadding;
-  final EdgeInsets footerPadding;
-  final EdgeInsets headerPadding;
-  final EdgeInsets cardPadding;
+
+  // group card
   final Color groupBackgroundColor;
+  final EdgeInsets groupMargin;
+  final EdgeInsets footerPadding;
+  final EdgeInsets groupItemPadding;
+  final EdgeInsets headerPadding;
   final bool stretchGroupHeight;
 
+  // card
+  final EdgeInsets cardPadding;
+
   const AppFlowyBoardConfig({
+    this.boardPadding = EdgeInsets.zero,
     this.cornerRadius = 6.0,
-    this.groupPadding = const EdgeInsets.symmetric(horizontal: 8),
+    this.groupMargin = const EdgeInsets.symmetric(horizontal: 8),
     this.groupItemPadding = const EdgeInsets.symmetric(horizontal: 12),
     this.footerPadding = const EdgeInsets.symmetric(horizontal: 12),
     this.headerPadding = const EdgeInsets.symmetric(horizontal: 16),
@@ -209,34 +216,37 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
     super.initState();
     _overlayEntry = BoardOverlayEntry(
       builder: (BuildContext context) {
-        return Stack(
-          alignment: AlignmentDirectional.topStart,
-          children: [
-            if (widget.background != null)
-              Container(
-                clipBehavior: Clip.hardEdge,
-                decoration: BoxDecoration(
-                  borderRadius:
-                      BorderRadius.circular(widget.config.cornerRadius),
+        return Padding(
+          padding: widget.config.boardPadding,
+          child: Stack(
+            alignment: AlignmentDirectional.topStart,
+            children: [
+              if (widget.background != null)
+                Container(
+                  clipBehavior: Clip.hardEdge,
+                  decoration: BoxDecoration(
+                    borderRadius:
+                        BorderRadius.circular(widget.config.cornerRadius),
+                  ),
+                  child: widget.background,
                 ),
-                child: widget.background,
+              ReorderFlex(
+                config: widget.reorderFlexConfig,
+                scrollController: widget.scrollController,
+                onReorder: widget.onReorder,
+                dataSource: widget.dataController,
+                interceptor: OverlappingDragTargetInterceptor(
+                  reorderFlexId: widget.dataController.identifier,
+                  acceptedReorderFlexId: widget.dataController.groupIds,
+                  delegate: widget.delegate,
+                  columnsState: widget.boardState,
+                ),
+                leading: widget.leading,
+                trailing: widget.trailing,
+                children: _buildColumns(),
               ),
-            ReorderFlex(
-              config: widget.reorderFlexConfig,
-              scrollController: widget.scrollController,
-              onReorder: widget.onReorder,
-              dataSource: widget.dataController,
-              interceptor: OverlappingDragTargetInterceptor(
-                reorderFlexId: widget.dataController.identifier,
-                acceptedReorderFlexId: widget.dataController.groupIds,
-                delegate: widget.delegate,
-                columnsState: widget.boardState,
-              ),
-              leading: widget.leading,
-              trailing: widget.trailing,
-              children: _buildColumns(),
-            ),
-          ],
+            ],
+          ),
         );
       },
       opaque: false,
@@ -321,20 +331,20 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
 
   EdgeInsets _marginFromIndex(int index) {
     if (widget.dataController.groupDatas.isEmpty) {
-      return widget.config.groupPadding;
+      return widget.config.groupMargin;
     }
 
     if (index == 0) {
       // remove the left padding of the first group
-      return widget.config.groupPadding.copyWith(left: 0);
+      return widget.config.groupMargin.copyWith(left: 0);
     }
 
     if (index == widget.dataController.groupDatas.length - 1) {
       // remove the right padding of the last group
-      return widget.config.groupPadding.copyWith(right: 0);
+      return widget.config.groupMargin.copyWith(right: 0);
     }
 
-    return widget.config.groupPadding;
+    return widget.config.groupMargin;
   }
 }
 

--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -20,31 +20,31 @@ class AppFlowyBoardScrollController {
 }
 
 class AppFlowyBoardConfig {
-  // overall board
-  final EdgeInsets boardPadding;
-  final double cornerRadius;
+  // board
+  final double boardCornerRadius;
 
-  // group card
+  // group
   final Color groupBackgroundColor;
+  final double groupCornerRadius;
   final EdgeInsets groupMargin;
-  final EdgeInsets footerPadding;
-  final EdgeInsets groupItemPadding;
-  final EdgeInsets headerPadding;
+  final EdgeInsets groupHeaderPadding;
+  final EdgeInsets groupBodyPadding;
+  final EdgeInsets groupFooterPadding;
   final bool stretchGroupHeight;
 
   // card
-  final EdgeInsets cardPadding;
+  final EdgeInsets cardMargin;
 
   const AppFlowyBoardConfig({
-    this.boardPadding = EdgeInsets.zero,
-    this.cornerRadius = 6.0,
-    this.groupMargin = const EdgeInsets.symmetric(horizontal: 8),
-    this.groupItemPadding = const EdgeInsets.symmetric(horizontal: 12),
-    this.footerPadding = const EdgeInsets.symmetric(horizontal: 12),
-    this.headerPadding = const EdgeInsets.symmetric(horizontal: 16),
-    this.cardPadding = const EdgeInsets.symmetric(horizontal: 3, vertical: 4),
+    this.boardCornerRadius = 6.0,
+    this.groupCornerRadius = 6.0,
     this.groupBackgroundColor = Colors.transparent,
+    this.groupMargin = const EdgeInsets.symmetric(horizontal: 8),
+    this.groupHeaderPadding = const EdgeInsets.symmetric(horizontal: 16),
+    this.groupBodyPadding = const EdgeInsets.symmetric(horizontal: 12),
+    this.groupFooterPadding = const EdgeInsets.symmetric(horizontal: 12),
     this.stretchGroupHeight = true,
+    this.cardMargin = const EdgeInsets.symmetric(horizontal: 3, vertical: 4),
   });
 }
 
@@ -216,37 +216,34 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
     super.initState();
     _overlayEntry = BoardOverlayEntry(
       builder: (BuildContext context) {
-        return Padding(
-          padding: widget.config.boardPadding,
-          child: Stack(
-            alignment: AlignmentDirectional.topStart,
-            children: [
-              if (widget.background != null)
-                Container(
-                  clipBehavior: Clip.hardEdge,
-                  decoration: BoxDecoration(
-                    borderRadius:
-                        BorderRadius.circular(widget.config.cornerRadius),
-                  ),
-                  child: widget.background,
+        return Stack(
+          alignment: AlignmentDirectional.topStart,
+          children: [
+            if (widget.background != null)
+              Container(
+                clipBehavior: Clip.hardEdge,
+                decoration: BoxDecoration(
+                  borderRadius:
+                      BorderRadius.circular(widget.config.boardCornerRadius),
                 ),
-              ReorderFlex(
-                config: widget.reorderFlexConfig,
-                scrollController: widget.scrollController,
-                onReorder: widget.onReorder,
-                dataSource: widget.dataController,
-                interceptor: OverlappingDragTargetInterceptor(
-                  reorderFlexId: widget.dataController.identifier,
-                  acceptedReorderFlexId: widget.dataController.groupIds,
-                  delegate: widget.delegate,
-                  columnsState: widget.boardState,
-                ),
-                leading: widget.leading,
-                trailing: widget.trailing,
-                children: _buildColumns(),
+                child: widget.background,
               ),
-            ],
-          ),
+            ReorderFlex(
+              config: widget.reorderFlexConfig,
+              scrollController: widget.scrollController,
+              onReorder: widget.onReorder,
+              dataSource: widget.dataController,
+              interceptor: OverlappingDragTargetInterceptor(
+                reorderFlexId: widget.dataController.identifier,
+                acceptedReorderFlexId: widget.dataController.groupIds,
+                delegate: widget.delegate,
+                columnsState: widget.boardState,
+              ),
+              leading: widget.leading,
+              trailing: widget.trailing,
+              children: _buildColumns(),
+            ),
+          ],
         );
       },
       opaque: false,
@@ -288,7 +285,7 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
                   constraints: widget.groupConstraints,
                   child: AppFlowyBoardGroup(
                     margin: _marginFromIndex(columnIndex),
-                    itemMargin: widget.config.groupItemPadding,
+                    bodyPadding: widget.config.groupBodyPadding,
                     headerBuilder: _buildHeader,
                     footerBuilder: widget.footerBuilder,
                     cardBuilder: widget.cardBuilder,
@@ -296,7 +293,7 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
                     scrollController: ScrollController(),
                     phantomController: widget.phantomController,
                     onReorder: widget.dataController.moveGroupItem,
-                    cornerRadius: widget.config.cornerRadius,
+                    cornerRadius: widget.config.groupCornerRadius,
                     backgroundColor: widget.config.groupBackgroundColor,
                     dragStateStorage: widget.boardState,
                     dragTargetKeys: widget.boardState,

--- a/lib/src/widgets/board_group/group.dart
+++ b/lib/src/widgets/board_group/group.dart
@@ -82,7 +82,7 @@ class AppFlowyBoardGroup extends StatefulWidget {
 
   final EdgeInsets margin;
 
-  final EdgeInsets itemMargin;
+  final EdgeInsets bodyPadding;
 
   final double cornerRadius;
 
@@ -111,7 +111,7 @@ class AppFlowyBoardGroup extends StatefulWidget {
     this.onDragStarted,
     this.onDragEnded,
     this.margin = EdgeInsets.zero,
-    this.itemMargin = EdgeInsets.zero,
+    this.bodyPadding = EdgeInsets.zero,
     this.cornerRadius = 0.0,
     this.backgroundColor = Colors.transparent,
     this.stretchGroupHeight = true,
@@ -177,7 +177,7 @@ class _AppFlowyBoardGroupState extends State<AppFlowyBoardGroup> {
 
         reorderFlex = Flexible(
           fit: widget.stretchGroupHeight ? FlexFit.tight : FlexFit.loose,
-          child: Padding(padding: widget.itemMargin, child: reorderFlex),
+          child: Padding(padding: widget.bodyPadding, child: reorderFlex),
         );
 
         return Container(


### PR DESCRIPTION

1. Add missing vertical margin for the first and last group
2. Use LongPressDraggable instead of Draggable on mobile, so that the dragging behavior won't conflict with the scrolling behavior.
3.  Improve the naming. **Padding** represents the amount of inner space an element has, while the **Margin** is whitespace available surrounding an element.
![image](https://github.com/AppFlowy-IO/appflowy-board/assets/14248245/cc0e9986-451c-4e29-b59a-08665c3ec27c)
