### PR TITLE
Fix exception when running on the web

### DIFF
--- a/lib/src/widgets/reorder_flex/drag_target.dart
+++ b/lib/src/widgets/reorder_flex/drag_target.dart
@@ -2,9 +2,11 @@ import 'dart:io';
 
 import 'package:appflowy_board/appflowy_board.dart';
 import 'package:appflowy_board/src/utils/log.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:provider/provider.dart';
+
 import '../transitions.dart';
 
 abstract class DragTargetData {
@@ -198,7 +200,7 @@ class _ReorderDragTargetState<T extends DragTargetData>
     );
 
     if (draggableWidget == null) {
-      if ((Platform.isIOS || Platform.isAndroid)) {
+      if (!kIsWeb && (Platform.isIOS || Platform.isAndroid)) {
         // On mobile, we use [LongPressDraggable] to avoid conflicts with scrolling screen behavior. The configuration of [LongPressDraggable] is the same as [Draggable].
         return LongPressDraggable<DragTargetData>(
           axis: widget.dragDirection,


### PR DESCRIPTION
When you run the `example/lib/main.dart` on the web, you get:
![image](https://github.com/AppFlowy-IO/appflowy-board/assets/1719665/b6447b3f-8e98-4136-a593-3daf58cc5710)

```
======== Exception caught by widgets library =======================================================
The following UnsupportedError was thrown building DragTarget<FlexDragTargetData>(dirty, state: _DragTargetState<FlexDragTargetData>#800e2):
Unsupported operation: Platform._operatingSystem

The relevant error-causing widget was: 
  DragTarget<FlexDragTargetData> DragTarget:file:///home/dsyrstad/IdeaProjects/appflowy-board/lib/src/widgets/reorder_flex/drag_target.dart:127:25
When the exception was thrown, this was the stack: 
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 294:3       throw_
dart-sdk/lib/_internal/js_dev_runtime/patch/io_patch.dart 244:5                   _operatingSystem
dart-sdk/lib/io/platform_impl.dart 56:40                                          get operatingSystem
dart-sdk/lib/io/platform.dart 83:44                                               get operatingSystem
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 1430:8  get
dart-sdk/lib/io/platform.dart 161:46                                              get isIOS
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 1430:8  get
packages/appflowy_board/src/widgets/reorder_flex/drag_target.dart 201:21          [_buildDraggableWidget]
```

This is due to `drag_target.dart` blindly checking the `Platform`, which doesn't work on web. This PR fixes the issue by checked for `kIsWeb` first.