### PR TITLE
fix: remove default thumbVisibility setting

### DIFF
--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -239,7 +239,6 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
               ),
             Scrollbar(
               controller: _scrollController,
-              thumbVisibility: true,
               child: SingleChildScrollView(
                 scrollDirection: widget.reorderFlexConfig.direction,
                 controller: _scrollController,


### PR DESCRIPTION
When `thumbVisibility` is true, the scrollbar thumb will remain visible without the fade animation
Now we need remove it to custom scrollbar themes