### PR TITLE
feat: Add customizable background color to group data

### DIFF
--- a/lib/src/widgets/board.dart
+++ b/lib/src/widgets/board.dart
@@ -306,7 +306,7 @@ class _AppFlowyBoardContentState extends State<_AppFlowyBoardContent> {
                 phantomController: widget.phantomController,
                 onReorder: widget.boardController.moveGroupItem,
                 cornerRadius: widget.config.groupCornerRadius,
-                backgroundColor: widget.config.groupBackgroundColor,
+                backgroundColor: dataSource.groupData.backgroundColor ?? widget.config.groupBackgroundColor,
                 dragStateStorage: widget.boardState,
                 dragTargetKeys: widget.boardState,
                 reorderFlexAction: reorderFlexAction,

--- a/lib/src/widgets/board_group/group_data.dart
+++ b/lib/src/widgets/board_group/group_data.dart
@@ -194,6 +194,7 @@ class AppFlowyGroupData<CustomData> extends ReoderFlexItem with EquatableMixin {
   AppFlowyGroupData({
     required this.id,
     required String name,
+    this.backgroundColor,
     this.customData,
     List<AppFlowyGroupItem> items = const [],
   })  : _items = items,
@@ -206,6 +207,7 @@ class AppFlowyGroupData<CustomData> extends ReoderFlexItem with EquatableMixin {
   final String id;
   AppFlowyGroupHeaderData headerData;
   final CustomData? customData;
+  final Color? backgroundColor;
 
   final List<AppFlowyGroupItem> _items;
 


### PR DESCRIPTION
Introduces an optional backgroundColor property to AppFlowyGroupData, allowing individual group backgrounds to override the default board configuration. Updates board widget to use the group's background color if provided.

Example:
<img width="2394" height="1210" alt="localhost_61917_" src="https://github.com/user-attachments/assets/32482fef-bf04-4d38-8c9e-d8627c01ff33" />
